### PR TITLE
Return image with max dimension when requesting larger images

### DIFF
--- a/Classes/Utility/MetricsUtility.php
+++ b/Classes/Utility/MetricsUtility.php
@@ -58,9 +58,17 @@ class MetricsUtility
             throw new InvalidArgumentException('Width or height must be greater than zero.', 1745092984);
         }
 
-        if ($maxImageDimensions = (int) ($this->configRequest->getConfig()['maxImageDimensions'] ?? $this->settingsUtility->get('maxImageDimensions'))) {
+        if ($maxImageDimensions = (int)($this->configRequest->getConfig()['maxImageDimensions'] ?? $this->settingsUtility->get('maxImageDimensions'))) {
             if ($this->configRequest->getWidth() > $maxImageDimensions || $this->configRequest->getHeight() > $maxImageDimensions) {
-                throw new InvalidArgumentException('Dimensions exceed the maximum length.', 1745092985);
+                if ($this->configRequest->getWidth() > $this->configRequest->getHeight()) {
+                    $this->configRequest->setWidth($maxImageDimensions);
+                    $this->configRequest->setHeight($this->aspectRatio->getHeight($maxImageDimensions));
+                } else {
+                    $this->configRequest->setHeight($maxImageDimensions);
+                    $this->configRequest->setWidth($this->aspectRatio->getWidth($maxImageDimensions));
+                }
+                // reevaluate with new sizes
+                $this->evaluate();
             }
         }
 


### PR DESCRIPTION
This code changes the behavior of the extension to return the largest possible image instead of throwing an error.

This helps, when the image is used on larger screens with full-width elements. We ensure, the server is not overloaded with very large images requested by 4k, 5k / 8k monitors by respecting the maxImageDimension settings. And for the user we return the largest possible image instead of showing just the blury 80px image.

Issue #14