### PR TITLE
Respect crop area for aspect ratio

### DIFF
--- a/Classes/Utility/ImageUtility.php
+++ b/Classes/Utility/ImageUtility.php
@@ -141,6 +141,12 @@ class ImageUtility
             return (string) $value;
         }
 
+        if (($cropArea = $this->getCropArea())
+            && ($absoluteCropArea = $cropArea->makeAbsoluteBasedOnFile($this->file)->asArray())
+            && !empty($absoluteCropArea[$property])) {
+            return (string) $absoluteCropArea[$property];
+        }
+
         if ($this->file->hasProperty($property) && $value = $this->file->getProperty($property)) {
             return (string) $value;
         }


### PR DESCRIPTION
Editors can crop images to a different size and aspect ratio in the backend. If the aspect ratio is not defined otherwise in the ViewHelper, the crop area is now used to size the image.

Issue #13