### PR TITLE
Fix evaluation order for freeAspectRatio argument

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -51,7 +51,7 @@ class ImageViewHelper extends AbstractViewHelper
 
         // Image rendering settings
         $this->registerArgument('aspectRatio', 'string|array', 'Set the aspect ratio of the image, or create a array for different formats like "{xs:\'1:1\', sm:\'4:3\', lg:\'16:9\'}"');
-        $this->registerArgument('freeAspectRatio', 'bool', 'Set free aspect ratio. This means that the image will be cropped to the given width and height. (This is the same than "aspectRatio=\'free\'")', false, false);
+        $this->registerArgument('freeAspectRatio', 'bool', 'Set free aspect ratio. This means that the image will be cropped to the given width and height.', false, false);
         $this->registerArgument('retina', 'bool', 'If set, the image will be rendered in retina mode. This means that the image will be rendered in double size and scaled down to the original size. This is useful for high-resolution displays.');
 
         // Some attributes for the image tag
@@ -113,10 +113,6 @@ class ImageViewHelper extends AbstractViewHelper
 
     protected function determineAspectRatio(): AspectRatioUtility
     {
-        if ($this->arguments['freeAspectRatio'] ?? false) {
-            return $this->aspectRatioUtiltiy->add([1, 1]);
-        }
-
         if ($aspectRatio = $this->arguments['aspectRatio']) {
             return $this->aspectRatioUtiltiy->addList($aspectRatio);
         }
@@ -127,6 +123,10 @@ class ImageViewHelper extends AbstractViewHelper
 
         if (($width = $this->imageUtility->getProperty('width')) && ($height = $this->imageUtility->getProperty('height'))) {
             return $this->aspectRatioUtiltiy->add([(int) $width, (int) $height]);
+        }
+
+        if ($this->arguments['freeAspectRatio'] ?? false) {
+            return $this->aspectRatioUtiltiy->add([1, 1]);
         }
 
         return $this->aspectRatioUtiltiy;


### PR DESCRIPTION
Remove invalid description in argument registration.

Evaluate argument `freeAspectRatio` last to apply default aspect ratios correctly.

Issue #18