### PR TITLE
[TASK] Round width and height calculations

### DIFF
--- a/Classes/Entity/AspectRatio.php
+++ b/Classes/Entity/AspectRatio.php
@@ -85,12 +85,12 @@ class AspectRatio
 
     public function getHeight(int $width): int
     {
-        return (int) floor($width / $this->getX() * $this->getY());
+        return (int) round($width / $this->getX() * $this->getY());
     }
 
     public function getWidth(int $height): int
     {
-        return (int) floor($height / $this->getY() * $this->getX());
+        return (int) round($height / $this->getY() * $this->getX());
     }
 
     public function toArray(): array


### PR DESCRIPTION
Currently width and height calculations are floored.

The rounding difference can result in an image being loaded twice and minor layout shifts.

In my case the original image is 8420x4736 and the thumbnail gets resized to 80x44. Then the Image is first fetched in e.g. 1280x704 and then again with 1280x720  as the image space is slightly raised after the first load...

rounding instead of floor helps in most cases as a quick fix.