### PR TITLE
Prevent errors on empty aspectRatio

### DIFF
--- a/Classes/Utility/MetricsUtility.php
+++ b/Classes/Utility/MetricsUtility.php
@@ -60,6 +60,9 @@ class MetricsUtility
 
         if ($maxImageDimensions = (int)($this->configRequest->getConfig()['maxImageDimensions'] ?? $this->settingsUtility->get('maxImageDimensions'))) {
             if ($this->configRequest->getWidth() > $maxImageDimensions || $this->configRequest->getHeight() > $maxImageDimensions) {
+                if (!$this->aspectRatio) {
+                    $this->aspectRatio = new AspectRatio($this->configRequest->getWidth(), $this->configRequest->getHeight());
+                }
                 if ($this->configRequest->getWidth() > $this->configRequest->getHeight()) {
                     $this->configRequest->setWidth($maxImageDimensions);
                     $this->configRequest->setHeight($this->aspectRatio->getHeight($maxImageDimensions));


### PR DESCRIPTION
With patch #16 the max-dimension feature was introduced. `$this->aspectRatio` can be null at this point. We now create a new AspectRatio instance with the requested ratio to apply the max-dimensions accordingly.