### PR TITLE
Fix type error wenn uid is given as src

### DIFF
--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -135,7 +135,7 @@ class ImageViewHelper extends AbstractViewHelper
     protected function initializeImage(): void
     {
         $this->imageUtility->setFile(
-            $this->arguments['src'],
+            is_int($this->arguments['src']) ? (string)$this->arguments['src'] : $this->arguments['src'],
             $this->arguments['image'],
             $this->arguments['treatIdAsReference'] ?? false
         );


### PR DESCRIPTION
The `src` can be "a path to a file, a combined FAL identifier or an uid (int)". When an uid is given, we need to convert the integer value to a string to prevent this error:


```
(1/1) TypeError
Zeroseven\Pictureino\Utility\ImageUtility::setFile(): Argument #1 ($src) must be of type ?string, int given, called in /var/www/html/vendor/zeroseven/pictureino/Classes/ViewHelpers/ImageViewHelper.php on line 137
```